### PR TITLE
Fix SQL injection vulnerabilities in PostgreSQL query rendering

### DIFF
--- a/app/persistence/postgresql/BaseQueryRenderer.scala
+++ b/app/persistence/postgresql/BaseQueryRenderer.scala
@@ -1,6 +1,7 @@
 package persistence.postgresql
 
 import persistence.querylang.{ GTE, LTE, _ }
+import PGSqlUtils._
 
 case class RenderContext(geometryColumn: String, bbox: Option[String] = None)
 
@@ -15,7 +16,7 @@ trait BaseQueryRenderer extends QueryRenderer[String, RenderContext] {
     case ToDate(date, fmt)   => renderToDate(date, fmt)
     case LiteralBoolean(b)   => if (b) " true " else " false "
     case LiteralNumber(n)    => s" ${n.toString} "
-    case LiteralString(s)    => s" '$s' "
+    case LiteralString(s)    => s" ${safeLiteralString(s)} "
     case p @ PropertyExpr(_) => renderPropertyExpr(p)
   }
 
@@ -51,14 +52,14 @@ trait BaseQueryRenderer extends QueryRenderer[String, RenderContext] {
   def renderRegexPredicate(
     lhs: AtomicExpr,
     rhs: RegexExpr
-  )(implicit ctxt: RenderContext): String = s" ${renderAtomicCasting(lhs, rhs)} ~ '${rhs.pattern}'"
+  )(implicit ctxt: RenderContext): String = s" ${renderAtomicCasting(lhs, rhs)} ~ ${safeLiteralString(rhs.pattern)}"
 
   def renderLikePredicate(
     lhs:           AtomicExpr,
     rhs:           LikeExpr,
     caseSensitive: Boolean    = true
-  )(implicit ctxt: RenderContext): String = if (caseSensitive) s" ${renderAtomicCasting(lhs, rhs)} like '${rhs.pattern}'"
-  else s" ${renderAtomicCasting(lhs, rhs)} ilike '${rhs.pattern}'"
+  )(implicit ctxt: RenderContext): String = if (caseSensitive) s" ${renderAtomicCasting(lhs, rhs)} like ${safeLiteralString(rhs.pattern)}"
+  else s" ${renderAtomicCasting(lhs, rhs)} ilike ${safeLiteralString(rhs.pattern)}"
 
   def renderNullTestPredicate(
     lhs: AtomicExpr,
@@ -74,15 +75,15 @@ trait BaseQueryRenderer extends QueryRenderer[String, RenderContext] {
 
   def renderIntersects(wkt: Option[String], geometryColumn: String, bbox: Option[String]): String = {
     wkt match {
-      case Some(geo) => s""" ST_Intersects( $geometryColumn, '$geo' )"""
-      case _         => s""" ST_Intersects( $geometryColumn, '${bbox.getOrElse("POINT EMPTY")}' )"""
+      case Some(geo) => s""" ST_Intersects( $geometryColumn, ${safeWkt(geo)} )"""
+      case _         => s""" ST_Intersects( $geometryColumn, ${safeLiteralString(bbox.getOrElse("POINT EMPTY"))} )"""
     }
   }
 
   def renderJsonContains(
     lhs: PropertyExpr,
     rhs: LiteralString
-  )(implicit ctxt: RenderContext): String = s"${renderPropertyExpr(lhs)}::jsonb @> '${rhs.value}'::jsonb "
+  )(implicit ctxt: RenderContext): String = s"${renderPropertyExpr(lhs)}::jsonb @> ${safeLiteralString(rhs.value)}::jsonb"
 
   def render(expr: BooleanExpr)(implicit ctxt: RenderContext): String = expr match {
     case BooleanAnd(lhs, rhs)              => renderBooleanAnd(lhs, rhs)

--- a/app/persistence/postgresql/PGExpression.scala
+++ b/app/persistence/postgresql/PGExpression.scala
@@ -1,6 +1,7 @@
 package persistence.postgresql
 
 import persistence.FldSortSpec
+import PGSqlUtils._
 
 /**
  * Created by Karel Maesen, Geovise BVBA on 06/11/2019.
@@ -10,7 +11,7 @@ trait PGExpression {
   //TODO -- change parameter flds to Field Type
   def fldSpecToComponents(flds: String): Seq[String] = flds.split("\\.").toIndexedSeq
 
-  protected def quoteField(str: String) = s"'$str'"
+  protected def quoteField(str: String) = safeLiteralString(str)
 
   def intersperse[A](a: Seq[A], b: Seq[A]): Seq[A] = a match {
     case first +: rest => first +: intersperse(b, rest)

--- a/app/persistence/postgresql/PGJsonQueryRenderer.scala
+++ b/app/persistence/postgresql/PGJsonQueryRenderer.scala
@@ -1,6 +1,7 @@
 package persistence.postgresql
 
 import persistence.querylang._
+import PGSqlUtils._
 
 /**
  * Created by Karel Maesen, Geovise BVBA on 23/01/15.
@@ -49,6 +50,6 @@ object PGJsonQueryRenderer extends BaseQueryRenderer {
   }
 
   private def path2VariadicList(propertyExpr: PropertyExpr): String =
-    "'" + propertyExpr.path.replaceAll("\\.", "','") + "'"
+    propertyExpr.path.split("\\.").map(safeLiteralString).mkString(",")
 
 }

--- a/app/persistence/postgresql/PGSqlUtils.scala
+++ b/app/persistence/postgresql/PGSqlUtils.scala
@@ -1,0 +1,18 @@
+package persistence.postgresql
+
+import Exceptions.InvalidQueryException
+import org.geolatte.geom.codec.Wkt
+
+import scala.util.{ Failure, Success, Try }
+
+object PGSqlUtils {
+  def safeQuotes(value: String): String = value.replace("'", "''")
+  def safeLiteralString(value: String): String = s"'${safeQuotes(value)}'"
+  def safeWkt(wkt: String): String = Try(Wkt.toWkt(Wkt.fromWkt(wkt))) match {
+    case Success(safe) => safeLiteralString(safe)
+    case Failure(_)    => throw InvalidQueryException(s"Invalid WKT geometry: $wkt")
+  }
+  def safeIdentifier(name: String): String = s""""${escapeIdentifier(name)}""""
+
+  private def escapeIdentifier(name: String): String = name.replace("\"", "\"\"")
+}

--- a/app/persistence/postgresql/PostgresqlRepository.scala
+++ b/app/persistence/postgresql/PostgresqlRepository.scala
@@ -20,6 +20,7 @@ import slick.basic.DatabasePublisher
 import slick.jdbc.PostgresProfile.api._
 import slick.jdbc.hikaricp.HikariCPJdbcDataSource
 import slick.jdbc.{ GetResult, PositionedResult }
+import PGSqlUtils._
 import utilities.{ JsonUtils, Utils }
 
 import java.sql.Statement
@@ -251,11 +252,11 @@ class PostgresqlRepository @Inject() (
 
     val from =
       if (!spatialQuery.explode)
-        s"${quote(db)}.${quote(collection)}"
+        s"${safeIdentifier(db)}.${safeIdentifier(collection)}"
       else {
         val wq = Sql.windowFilterExpr(spatialQuery)
           .map(q => s" where $q").getOrElse("")
-        s"(select id, (st_dump(geometry)).geom as geometry, json from ${quote(db)}.${quote(collection)} $wq ) xx"
+        s"(select id, (st_dump(geometry)).geom as geometry, json from ${safeIdentifier(db)}.${safeIdentifier(collection)} $wq ) xx"
       }
 
     //get the count
@@ -312,7 +313,7 @@ class PostgresqlRepository @Inject() (
 
   override def distinct(db: String, collection: String, spatialQuery: SpatialQuery,
                         projection: SimpleProjection, queryTimeout: Duration = Duration.Inf): Future[List[String]] = {
-    val from = s"${quote(db)}.${quote(collection)}"
+    val from = s"${safeIdentifier(db)}.${safeIdentifier(collection)}"
 
     runOnDb("distinct", queryTimeout)(Sql.SELECT_DISTINCT(from, spatialQuery, projection)).map(_.filter(s => s != null).sorted.toList)
   }
@@ -517,10 +518,6 @@ class PostgresqlRepository @Inject() (
   //
   //    Note that we cannot use prepared statements for DDL's
 
-  //TODO -- should we check for quotes, spaces etc.  in str?
-  // alternative is to use escapeSql in the org.apache.commons.lang.StringEscapeUtils
-  private def quote(str: String): String = "\"" + str + "\""
-
   private def single_quote(str: String): String = "'" + str + "'"
 
   private val tr = (__ \ "geometry").json.prune
@@ -568,7 +565,7 @@ class PostgresqlRepository @Inject() (
       case _ =>
         def colName(s: String): String = if (s.trim.startsWith("properties.")) s.trim.substring(11) else s.trim
 
-        if (query.sort.isEmpty) query.metadata.pkey else query.sort.map(f => s""" "${colName(f.fld)}" ${f.direction} """) mkString ","
+        if (query.sort.isEmpty) query.metadata.pkey else query.sort.map(f => s"${safeIdentifier(colName(f.fld))} ${f.direction}") mkString ","
     }
 
     def wktGeometry(query: SpatialQuery): Option[String] = {
@@ -578,7 +575,7 @@ class PostgresqlRepository @Inject() (
     def windowFilterExpr(query: SpatialQuery): Option[String] = {
       val geomCol = if (query.metadata.jsonTable) "geometry" else query.metadata.geometryColumn
 
-      def bboxIntersectionRenderer(wkt: String) = s"$geomCol && ${single_quote(wkt)}::geometry"
+      def bboxIntersectionRenderer(wkt: String) = s"$geomCol && ${safeLiteralString(wkt)}::geometry"
 
       val bboxGeom = wktGeometry(query)
       bboxGeom.map(bboxIntersectionRenderer)
@@ -602,7 +599,7 @@ class PostgresqlRepository @Inject() (
       } else PGRegularQueryRenderer
       val geomCol = if (query.metadata.jsonTable) "geometry" else query.metadata.geometryColumn
 
-      def geomIntersectionRenderer(wkt: String) = s"ST_Intersects($geomCol, ${single_quote(wkt)}::geometry)"
+      def geomIntersectionRenderer(wkt: String) = s"ST_Intersects($geomCol, ${safeWkt(wkt)}::geometry)"
 
       val windowOpt = windowFilterExpr(query)
       val bboxGeom = wktGeometry(query: SpatialQuery)
@@ -687,18 +684,18 @@ class PostgresqlRepository @Inject() (
     }
 
     def UPDATE_DATA(db: String, col: String, where: String, json: String, geom: String) = {
-      sqlu"""UPDATE #${quote(db)}.#${quote(col)}
+      sqlu"""UPDATE #${safeIdentifier(db)}.#${safeIdentifier(col)}
           SET json = $json::json, geometry = $geom::geometry
           WHERE #$where
        """
     }
 
-    def CREATE_SCHEMA(dbname: String) = sqlu"create schema #${quote(dbname)}"
+    def CREATE_SCHEMA(dbname: String) = sqlu"create schema #${safeIdentifier(dbname)}"
 
-    def DROP_SCHEMA(dbname: String) = sqlu"drop schema #${quote(dbname)} CASCADE"
+    def DROP_SCHEMA(dbname: String) = sqlu"drop schema #${safeIdentifier(dbname)} CASCADE"
 
     def CREATE_METADATA_TABLE_IN(dbname: String) =
-      sqlu"""CREATE TABLE #${quote(dbname)}.#${quote(MetadataCollection)} (
+      sqlu"""CREATE TABLE #${safeIdentifier(dbname)}.#${safeIdentifier(MetadataCollection)} (
               #${toColName(ExtentField)} JSON,
               #${toColName(IndexLevelField)} INT,
               #${toColName(IdTypeField)} VARCHAR(120),
@@ -710,7 +707,7 @@ class PostgresqlRepository @Inject() (
        """
 
     def CREATE_VIEW_TABLE_IN(dbname: String) =
-      sqlu"""CREATE TABLE #${quote(dbname)}.#${quote(ViewCollection)} (
+      sqlu"""CREATE TABLE #${safeIdentifier(dbname)}.#${safeIdentifier(ViewCollection)} (
               COLLECTION VARCHAR,
               VIEW_NAME VARCHAR,
               VIEW_DEF JSON,
@@ -720,7 +717,7 @@ class PostgresqlRepository @Inject() (
 
     def CREATE_COLLECTION_TABLE(dbname: String, tableName: String, encodedAsJsonb: Boolean) = {
       val typeOfJsonField = if (encodedAsJsonb) "JSONB" else "JSON"
-      sqlu"""CREATE TABLE #${quote(dbname)}.#${quote(tableName)} (
+      sqlu"""CREATE TABLE #${safeIdentifier(dbname)}.#${safeIdentifier(tableName)} (
               id VARCHAR(255) PRIMARY KEY,
               geometry GEOMETRY,
               json #${typeOfJsonField}
@@ -741,34 +738,34 @@ class PostgresqlRepository @Inject() (
     }
 
     def CREATE_COLLECTION_ID_INDEX(dbname: String, tableName: String, idType: String) =
-      sqlu"""CREATE INDEX #${quote("idx_" + tableName + "_id")}
-             ON #${quote(dbname)}.#${quote(tableName)} ( (json_extract_path_text(json, 'id')::#$idType) )
+      sqlu"""CREATE INDEX #${safeIdentifier("idx_" + tableName + "_id")}
+             ON #${safeIdentifier(dbname)}.#${safeIdentifier(tableName)} ( (json_extract_path_text(json, 'id')::#$idType) )
      """
 
     def CREATE_COLLECTION_JSONB_PATH_OPS_INDEX(dbname: String, tableName: String, idType: String) =
-      sqlu"""CREATE INDEX #${quote("idx_" + tableName + "_jsonb_path")}
-             ON #${quote(dbname)}.#${quote(tableName)} USING gin(json jsonb_path_ops);
+      sqlu"""CREATE INDEX #${safeIdentifier("idx_" + tableName + "_jsonb_path")}
+             ON #${safeIdentifier(dbname)}.#${safeIdentifier(tableName)} USING gin(json jsonb_path_ops);
      """
 
     def CREATE_COLLECTION_SPATIAL_INDEX(dbname: String, tableName: String) =
-      sqlu"""CREATE INDEX #${quote(tableName + "_spatial_index")}
-              ON #${quote(dbname)}.#${quote(tableName)} USING GIST ( geometry )
+      sqlu"""CREATE INDEX #${safeIdentifier(tableName + "_spatial_index")}
+              ON #${safeIdentifier(dbname)}.#${safeIdentifier(tableName)} USING GIST ( geometry )
 
      """
 
     def INSERT_DATA(dbname: String, tableName: String, id: String, json: String, geometry: String) =
-      sqlu"""INSERT INTO #${quote(dbname)}.#${quote(tableName)}  (id, json, geometry)
+      sqlu"""INSERT INTO #${safeIdentifier(dbname)}.#${safeIdentifier(tableName)}  (id, json, geometry)
              VALUES ($id, $json::json, $geometry::geometry)
        """
 
     def UPSERT_DATA(dbname: String, tableName: String, id: String, json: String, geometry: String) =
-      sqlu"""INSERT INTO #${quote(dbname)}.#${quote(tableName)}  (id, json, geometry)
+      sqlu"""INSERT INTO #${safeIdentifier(dbname)}.#${safeIdentifier(tableName)}  (id, json, geometry)
              VALUES ($id, $json::json, $geometry::geometry)
              ON CONFLICT (id) DO UPDATE SET json = EXCLUDED.json, geometry = EXCLUDED.geometry;
        """
 
     def DELETE_DATA(dbname: String, tableName: String, where: String) =
-      sqlu"""DELETE FROM #${quote(dbname)}.#${quote(tableName)}
+      sqlu"""DELETE FROM #${safeIdentifier(dbname)}.#${safeIdentifier(tableName)}
         WHERE #$where
      """
 
@@ -777,12 +774,12 @@ class PostgresqlRepository @Inject() (
               where
               table_schema = ${single_quote(dbname)}
               and table_type = 'BASE TABLE'
-              and table_name != ${quote(MetadataCollection)}
+              and table_name != ${safeIdentifier(MetadataCollection)}
        """
     }
 
     def INSERT_METADATA_JSON_COLLECTION(dbname: String, tableName: String, md: Metadata) =
-      sqlu"""insert into #${quote(dbname)}.#${quote(MetadataCollection)} values(
+      sqlu"""insert into #${safeIdentifier(dbname)}.#${safeIdentifier(MetadataCollection)} values(
               ${Json.stringify(Json.toJson(md.envelope))}::json,
               ${md.level},
               ${md.idType},
@@ -794,49 +791,49 @@ class PostgresqlRepository @Inject() (
      """
 
     def INSERT_METADATA_REGISTERED(dbname: String, tableName: String, md: Metadata) =
-      sqlu"""insert into #${quote(dbname)}.#${quote(MetadataCollection)} values(
+      sqlu"""insert into #${safeIdentifier(dbname)}.#${safeIdentifier(MetadataCollection)} values(
               ${Json.stringify(Json.toJson(md.envelope))}::json,
               ${md.level},
               ${md.idType},
               ${tableName},
               ${md.geometryColumn},
               ${md.pkey},
-              ${md.encodedAsJsonb},
+              ${md.encodedAsJsonb}
               )
      """
 
     def SELECT_COLLECTION_NAMES(dbname: String): DBIO[Seq[String]] =
       sql"""select #$CollectionField
-        from  #${quote(dbname)}.#${quote(MetadataCollection)}
+        from  #${safeIdentifier(dbname)}.#${safeIdentifier(MetadataCollection)}
      """.as[String]
 
     def SELECT_COUNT(dbname: String, tablename: String): DBIO[Long] =
-      sql"select count(*) from #${quote(dbname)}.#${quote(tablename)}".as[Long].map(_.head)
+      sql"select count(*) from #${safeIdentifier(dbname)}.#${safeIdentifier(tablename)}".as[Long].map(_.head)
 
     def SELECT_METADATA(dbname: String, tablename: String): DBIO[Option[Metadata]] =
       sql"""select *
-            from #${quote(dbname)}.#${quote(MetadataCollection)}
+            from #${safeIdentifier(dbname)}.#${safeIdentifier(MetadataCollection)}
             where #$CollectionField = $tablename
       """.as[Metadata].map(_.headOption)
 
     def DELETE_METADATA(dbname: String, tablename: String) =
       sqlu"""delete
-             from #${quote(dbname)}.#${quote(MetadataCollection)}
+             from #${safeIdentifier(dbname)}.#${safeIdentifier(MetadataCollection)}
              where #$CollectionField = $tablename
      """
 
     def DROP_TABLE(dbname: String, tablename: String) =
-      sqlu"drop table #${quote(dbname)}.#${quote(tablename)}"
+      sqlu"drop table #${safeIdentifier(dbname)}.#${safeIdentifier(tablename)}"
 
     def DELETE_VIEWS_FOR_TABLE(dbname: String, tablename: String) =
       sqlu"""
-         DELETE FROM #${quote(dbname)}.#${quote(ViewCollection)}
+         DELETE FROM #${safeIdentifier(dbname)}.#${safeIdentifier(ViewCollection)}
          WHERE COLLECTION = $tablename
      """
 
     def INSERT_VIEW(dbname: String, tableName: String, viewName: String, json: JsObject) =
       sqlu"""
-         INSERT INTO #${quote(dbname)}.#${quote(ViewCollection)} VALUES (
+         INSERT INTO #${safeIdentifier(dbname)}.#${safeIdentifier(ViewCollection)} VALUES (
            $tableName,
            $viewName,
            ${Json.stringify(json)}::json
@@ -845,7 +842,7 @@ class PostgresqlRepository @Inject() (
 
     def DELETE_VIEW(dbname: String, tableName: String, viewName: String) =
       sqlu"""
-         DELETE FROM #${quote(dbname)}.#${quote(ViewCollection)}
+         DELETE FROM #${safeIdentifier(dbname)}.#${safeIdentifier(ViewCollection)}
          WHERE COLLECTION = $tableName and VIEW_NAME = $viewName
      """
 
@@ -854,7 +851,7 @@ class PostgresqlRepository @Inject() (
     def GET_VIEW(dbname: String, coll: String, viewName: String) =
       sql"""
          SELECT VIEW_DEF
-         FROM #${quote(dbname)}.#${quote(ViewCollection)}
+         FROM #${safeIdentifier(dbname)}.#${safeIdentifier(ViewCollection)}
          WHERE COLLECTION = $coll AND VIEW_NAME = $viewName
      """.as[JsObject].map {
         _.headOption
@@ -863,7 +860,7 @@ class PostgresqlRepository @Inject() (
     def GET_VIEWS(dbname: String, coll: String) = {
       sql"""
          SELECT VIEW_DEF
-         FROM #${quote(dbname)}.#${quote(ViewCollection)}
+         FROM #${safeIdentifier(dbname)}.#${safeIdentifier(ViewCollection)}
          WHERE COLLECTION = $coll
      """.as[JsObject]
     }
@@ -875,15 +872,15 @@ class PostgresqlRepository @Inject() (
 
     def CREATE_INDEX(dbName: String, colName: String, indexName: String, path: Seq[String], cast: String) = {
       val pathExp = jsonFieldSelector(path)
-      sqlu"""CREATE INDEX #${quote(indexName)}
-             ON #${quote(dbName)}.#${quote(colName)} ( #$pathExp )
+      sqlu"""CREATE INDEX #${safeIdentifier(indexName)}
+             ON #${safeIdentifier(dbName)}.#${safeIdentifier(colName)} ( #$pathExp )
       """
     }
 
     def CREATE_INDEX_WITH_TRGM(dbName: String, colName: String, indexName: String, path: Seq[String], cast: String) = {
       val pathExp = jsonFieldSelector(path)
-      sqlu"""CREATE INDEX #${quote(indexName)}
-             ON #${quote(dbName)}.#${quote(colName)} using gist
+      sqlu"""CREATE INDEX #${safeIdentifier(indexName)}
+             ON #${safeIdentifier(dbName)}.#${safeIdentifier(colName)} using gist
              ( #$pathExp ) gist_trgm_ops)
       """
     }
@@ -897,7 +894,7 @@ class PostgresqlRepository @Inject() (
 
     def DROP_INDEX(db: String, col: String, indexName: String) =
       sqlu"""
-         DROP INDEX IF EXISTS #${quote(db)}.#${quote(indexName)}
+         DROP INDEX IF EXISTS #${safeIdentifier(db)}.#${safeIdentifier(indexName)}
      """
 
     implicit val getTableStatsResult: GetResult[TableStats] = GetResult(r => TableStats(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<,

--- a/test/integration/QueryAPISpec.scala
+++ b/test/integration/QueryAPISpec.scala
@@ -21,6 +21,7 @@ class QueryAPISpec extends InCollectionSpecification {
 
       The FeatureCollection /list should:
         return the objects contained within the specified bbox as json object      $e3
+        reject sql injection in geometry body parameter                            $e3b
         respond to the START query-param                                           $e4
         respond to the LIMIT query-param                                           $e5
         support the SORT parameter                                                 $e5b
@@ -83,6 +84,12 @@ class QueryAPISpec extends InCollectionSpecification {
       getList(testDbName, testColName, Map("bbox" -> bbox)).applyMatcher(
         res => (res.status must equalTo(OK)) and (res.responseBody must beSome(matchFeaturesInJson(featuresIn01)))
       )
+  }
+
+  def e3b = withTestFeatures(0, 10) {
+    (bbox: String, featuresIn01: JsArray) =>
+      getListBody(testDbName, testColName, "", s"SRID=4326;POINT(10 10)') OR TRUE --").applyMatcher(
+        res => res.status must equalTo(BAD_REQUEST))
   }
 
   def e4 = withTestFeatures(100, 10) {

--- a/test/integration/RestApi.scala
+++ b/test/integration/RestApi.scala
@@ -97,6 +97,9 @@ object FakeRequestResult {
   def POSTRaw(url: String, body: ByteString, format: Future[Result] => JsValue)(implicit app: Application) =
     FakeRequestResult(url = url, format = Some(format), requestBody = Some(body), mkRequest = makePostRequestRaw)
 
+  def POSTText(url: String, body: String, format: Future[Result] => JsValue)(implicit app: Application) =
+    FakeRequestResult(url = url, format = Some(format), requestBody = Some(body), mkRequest = makePostRequestText)
+
 }
 
 //This is for pattern match
@@ -176,6 +179,12 @@ trait RestApiDriver {
     Logger.info("Start /list on collection")
     val url = DATABASES / dbName / colName / FEATURECOLLECTION ? queryStr
     FakeRequestResult.GET(url, contentAsJsonStringStream)
+  }
+
+  def getListBody(dbName: String, colName: String, queryStr: String, reqBody: String) = {
+    Logger.info("Start /list on collection")
+    val url = DATABASES / dbName / colName / FEATURECOLLECTION ? queryStr
+    FakeRequestResult.POSTText(url, reqBody, contentAsJson)
   }
 
   def postUpsert(dbName: String, colName: String, reqBody: JsObject) = {
@@ -350,6 +359,10 @@ object UtilityMethods extends PlayRunners
   def makePostRequestRaw(url: String, body: Option[ByteString]) = FakeRequest(POST, url)
     .withHeaders("Accept" -> "application/json")
     .withRawBody(body.getOrElse(ByteString.empty))
+
+  def makePostRequestText(url: String, body: Option[String]) = FakeRequest(POST, url)
+    .withHeaders("Accept" -> "application/json")
+    .withTextBody(body.getOrElse(""))
 
   def makeDeleteRequest(url: String, body: Option[JsValue] = None) = FakeRequest(DELETE, url)
 


### PR DESCRIPTION
Replaces unsafe string interpolation in SQL queries with properly escaped and quote alternatives via a new PGSqlUtils utility object, preventing SQL injection through user-supplied geometry, literal strings and identifiers. Adds an integration test to verify that malformed WKT input in the geometry body parameter is rejected with a BAD_REQUEST response.