### PR TITLE
Support validation of WKT's with ZM dimensions

### DIFF
--- a/app/persistence/postgresql/PGSqlUtils.scala
+++ b/app/persistence/postgresql/PGSqlUtils.scala
@@ -6,13 +6,26 @@ import org.geolatte.geom.codec.Wkt
 import scala.util.{ Failure, Success, Try }
 
 object PGSqlUtils {
+  private val DimensionMarker = "(?i)\\s+ZM?(?=\\s*\\()".r
+
   def safeQuotes(value: String): String = value.replace("'", "''")
   def safeLiteralString(value: String): String = s"'${safeQuotes(value)}'"
-  def safeWkt(wkt: String): String = Try(Wkt.toWkt(Wkt.fromWkt(wkt))) match {
-    case Success(safe) => safeLiteralString(safe)
-    case Failure(_)    => throw InvalidQueryException(s"Invalid WKT geometry: $wkt")
-  }
+  def safeWkt(wkt: String): String =
+    validate(wkt)
+      .orElse(retryWithoutDimensionMarker(wkt))
+      .map(_ => safeLiteralString(wkt))
+      .getOrElse(throw InvalidQueryException(s"Invalid WKT geometry: $wkt"))
   def safeIdentifier(name: String): String = s""""${escapeIdentifier(name)}""""
+
+  private def validate(wkt: String): Try[Unit] =
+    Try(Wkt.fromWkt(wkt)).map(_ => ())
+
+  /** Try to validate the WKT after removing standard Z/ZM dimension markers that geolatte-geom 0.14 does not understand. */
+  private def retryWithoutDimensionMarker(wkt: String): Try[Unit] = {
+    val normalized = DimensionMarker.replaceAllIn(wkt, "")
+    if (normalized == wkt) Failure(InvalidQueryException(s"Invalid WKT geometry: $wkt"))
+    else validate(normalized)
+  }
 
   private def escapeIdentifier(name: String): String = name.replace("\"", "\"\"")
 }

--- a/test/persistence/postgresql/PGSqlUtilsSpec.scala
+++ b/test/persistence/postgresql/PGSqlUtilsSpec.scala
@@ -1,0 +1,45 @@
+package persistence.postgresql
+
+import org.specs2.mutable.Specification
+
+class PGSqlUtilsSpec extends Specification {
+  private def preservesOriginalWkt(wkt: String) =
+    PGSqlUtils.safeWkt(wkt) === s"'$wkt'"
+
+  "PGSqlUtils.safeWkt" should {
+    "canonicalize WKT that GeoLatte can decode" in {
+      PGSqlUtils.safeWkt(
+        "SRID=31370;POINT(10 12)"
+      ) === "'SRID=31370;POINT(10 12)'"
+    }
+
+    "reject a quoted SQL injection payload in WKT input" in {
+      PGSqlUtils.safeWkt("SRID=4326;POINT(10 10)') OR TRUE --") must throwA[Exceptions.InvalidQueryException]
+    }
+
+    "keep original WKT for standard Z and ZM variants after fallback validation" in {
+      val examples = Seq(
+        "POINT Z (1 2 3)",
+        "POINT ZM (1 2 4 5)",
+        "MULTIPOINT Z ((1 2 5),(3 4 6))",
+        "MULTIPOINT ZM ((1 2 5 6),(3 4 7 8))",
+        "LINESTRING Z (30 10 1,10 30 2,40 40 3)",
+        "LINESTRING ZM (30 10 1 4,10 30 2 5,40 40 3 6)",
+        "MULTILINESTRING Z ((10 10 0,20 20 1,10 40 2),(40 40 3,30 30 4,40 20 5,30 10 6))",
+        "MULTILINESTRING ZM ((10 10 0 100,20 20 1 101,10 40 2 102),(40 40 3 103,30 30 4 104,40 20 5 105,30 10 6 106))",
+        "POLYGON Z ((30 10 0,40 40 1,20 40 2,10 20 1,30 10 0))",
+        "POLYGON ZM ((30 10 0 1,40 40 1 2,20 40 2 3,10 20 1 4,30 10 0 1))",
+        "MULTIPOLYGON Z (((40 40 1,20 45 2,45 30 3,40 40 1)),((20 35 1,10 30 2,10 10 3,30 5 4,45 20 5,20 35 1),(30 20 1,20 15 2,20 25 3,30 20 1)))",
+        "MULTIPOLYGON ZM (((40 40 1 1,20 45 2 3,45 30 3 4,40 40 1 1)),((20 35 1 1,10 30 2 2,10 10 3 4,30 5 4 5,45 20 5 6,20 35 1 1),(30 20 1 1,20 15 2 2,20 25 3 3,30 20 1 1)))",
+        "GEOMETRYCOLLECTION Z (POINT Z (40 10 1),LINESTRING Z (10 10 1,20 20 2,10 40 3),POLYGON Z ((40 40 1,20 45 2,45 30 3,40 40 1)))",
+        "GEOMETRYCOLLECTION ZM (POINT ZM (40 10 1 2),LINESTRING ZM (10 10 1 2,20 20 2 3,10 40 3 4),POLYGON ZM ((40 40 1 1,20 45 2 2,45 30 3 3,40 40 1 1)))",
+
+        "SRID=31370;MULTIPOLYGON ZM(((118901.556 180399.729 0 0,118922.556 180399.729 0 0,118922.556 180420.729 0 0,118901.556 180399.729 0 0)))"
+      )
+
+      examples
+        .map(preservesOriginalWkt)
+        .reduce(_ and _)
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes the "Invalid WKT geometry: SRID=31370;MULTIPOLYGON ZM(((118901.556 1" on /count and /export calls when the WKT is supplied as an INTERSECTS query.

safeWkt uses geolatte geom version 0.8 which does not support ZM dimensions or other WKT dialects, which breaks the WKT penetration test validation. Upgrading to geolatte geom 1.10 would add this support but is a major rewrite. 

This PR implements a temporary workaround which strips the ZM if present to validate the WKT. It sends the original WKT though to not lose the dimensions later on in the chain.