### PR TITLE
Harden PostgreSQL query rendering against SQL injection

### DIFF
--- a/app/controllers/ExceptionHandlers.scala
+++ b/app/controllers/ExceptionHandlers.scala
@@ -33,7 +33,7 @@ trait ExceptionHandlers {
     case ex: QueryTimeoutException            => RequestTimeout("Operation timed out.")
     case ex: Throwable =>
       Logger.error(s"Internal server error with message : ${ex.getMessage}", ex)
-      InternalServerError(s"Internal server error ${ex.getClass.getCanonicalName} with message : ${ex.getMessage}")
+      InternalServerError("Internal server error.")
   }
 
 }

--- a/app/persistence/postgresql/PGJsonpathQueryRenderer.scala
+++ b/app/persistence/postgresql/PGJsonpathQueryRenderer.scala
@@ -1,15 +1,19 @@
 package persistence.postgresql
 
 import persistence.querylang._
+import PGSqlUtils.{ safeJsonpathString, safeLiteralString }
 
 object PGJsonpathQueryRenderer extends BaseQueryRenderer {
+
+  private def renderJsonpathPredicate(expression: String): String =
+    s" json @?? ${safeLiteralString(expression)}"
 
   override def renderComparisonPredicate(
                                           lhs: AtomicExpr,
                                           op: ComparisonOperator,
                                           rhs: AtomicExpr
                                         )(implicit ctxt: RenderContext): String = {
-    s" json @?? '${jsonpathExpr(lhs, op, rhs)}'"
+    renderJsonpathPredicate(jsonpathExpr(lhs, op, rhs))
   }
 
   def jsonpathExpr(
@@ -24,7 +28,7 @@ object PGJsonpathQueryRenderer extends BaseQueryRenderer {
     case ToDate(date, fmt) => renderToDate(date, fmt)
     case LiteralBoolean(b) => if (b) " true " else " false "
     case LiteralNumber(n) => s" ${n.toString} "
-    case LiteralString(s) => s" \"$s\" "
+    case LiteralString(s) => s" ${safeJsonpathString(s)} "
     case p@PropertyExpr(_) => renderPropertyExpr(p)
   }
 
@@ -37,9 +41,9 @@ object PGJsonpathQueryRenderer extends BaseQueryRenderer {
                                         is:  Boolean
                                       )(implicit ctxt: RenderContext): String =
     if (is) {
-      s" json @?? '${renderAtomic(lhs)} ? (@ ${sym(EQ)} null)'"
+      renderJsonpathPredicate(s"${renderAtomic(lhs)} ? (@ ${sym(EQ)} null)")
     } else {
-      s" json @?? '${renderAtomic(lhs)} ? (@ ${sym(NEQ)} null)'"
+      renderJsonpathPredicate(s"${renderAtomic(lhs)} ? (@ ${sym(NEQ)} null)")
     }
 
   override def renderToDate(
@@ -61,7 +65,7 @@ object PGJsonpathQueryRenderer extends BaseQueryRenderer {
                                      lhs: AtomicExpr,
                                      rhs: RegexExpr
                                    )(implicit ctxt: RenderContext): String =
-    s" json @?? '${renderAtomic(lhs)} ? (@ like_regex \"${rhs.pattern}\")'"
+    renderJsonpathPredicate(s"${renderAtomic(lhs)} ? (@ like_regex ${safeJsonpathString(rhs.pattern)})")
 
   override def renderLikePredicate(
                                     lhs: AtomicExpr,
@@ -80,7 +84,7 @@ object PGJsonpathQueryRenderer extends BaseQueryRenderer {
                                     lhs: PropertyExpr,
                                     rhs: LiteralString
                                   )(implicit ctxt: RenderContext): String =
-    s"${PGJsonbFallbackQueryRenderer.renderPropertyExpr(lhs)} @> '${rhs.value}'::jsonb "
+    s"${PGJsonbFallbackQueryRenderer.renderPropertyExpr(lhs)} @> ${safeLiteralString(rhs.value)}::jsonb "
 
   override def renderBetween(
                               lhs: AtomicExpr,
@@ -137,4 +141,3 @@ object PGJsonbFallbackQueryRenderer extends BaseQueryRenderer with PGExpression 
                            ): String = s" to_date(${renderAtomicPropsAsText(date)}, ${renderAtomicPropsAsText(fmt)}) "
 
 }
-

--- a/app/persistence/postgresql/PGRegularQueryRenderer.scala
+++ b/app/persistence/postgresql/PGRegularQueryRenderer.scala
@@ -1,12 +1,17 @@
 package persistence.postgresql
 
 import persistence.querylang._
+import PGSqlUtils.safeIdentifier
 
 /**
  * Created by Karel Maesen, Geovise BVBA on 16/04/16.
  */
 object PGRegularQueryRenderer extends BaseQueryRenderer {
 
+  // A property path can only reach us through one of the parsers, and neither
+  // admits a double quote in a name. Quoting through `safeIdentifier` rather
+  // than by hand keeps that from being the only thing standing between a path
+  // and SQL statement context, should a grammar ever widen.
   override def renderPropertyExpr(expr: PropertyExpr): String = {
     val withoutPrefix =
       if (expr.path.trim.startsWith("properties.")) {
@@ -14,7 +19,7 @@ object PGRegularQueryRenderer extends BaseQueryRenderer {
       } else {
         expr.path
       }
-    s""""$withoutPrefix""""
+    safeIdentifier(withoutPrefix)
   }
 
   override def cast(exp: Expr): String = "" // don't cast

--- a/app/persistence/postgresql/PGSqlUtils.scala
+++ b/app/persistence/postgresql/PGSqlUtils.scala
@@ -10,6 +10,52 @@ object PGSqlUtils {
   def safeLiteralString(value: String): String = s"'${safeQuotes(value)}'"
 
   /**
+   * Quote a string for use as a PostgreSQL jsonpath string literal.
+   *
+   * This escapes the jsonpath/JSON string layer only. The complete jsonpath
+   * expression must still be passed through `safeLiteralString` before being
+   * embedded in SQL.
+   *
+   * JSON requires an escape for exactly three things — the closing quote, the
+   * backslash itself, and the control characters — so the cases below are the
+   * complete set. Everything else, `/` and non-ASCII included, is legal
+   * unescaped and is left alone.
+   *
+   * Escaping the backslash is not only a matter of not ending the string early:
+   * PostgreSQL's jsonpath lexer accepts unknown escapes and silently drops the
+   * backslash, so an unescaped `\d` from a user would reach the value as a bare
+   * `d`.
+   */
+  def safeJsonpathString(value: String): String = {
+    val escaped = new StringBuilder(value.length)
+    value.foreach {
+      case '"'  => escaped.append("\\\"")
+      case '\\' => escaped.append("\\\\")
+      // The five named forms are the same characters the fallback below would
+      // catch anyway; they only keep the generated SQL readable in logs.
+      case '\b' => escaped.append("\\b")
+      case '\f' => escaped.append("\\f")
+      case '\n' => escaped.append("\\n")
+      case '\r' => escaped.append("\\r")
+      case '\t' => escaped.append("\\t")
+      // The remaining control characters — think NUL, ESC, vertical tab. They
+      // have no printable shape and no shorthand of their own, so JSON wants
+      // them written as a backslash, then a u, then four hex digits (the code
+      // point 1 becomes a six-character escape).
+      case c if c < FirstPrintableChar => escaped.append("\\u%04x".format(c.toInt))
+      case c                           => escaped.append(c)
+    }
+    s""""$escaped""""
+  }
+
+  /**
+   * The space, the lowest character with a printable form. Everything below it
+   * is a control character, which is exactly the set JSON refuses to carry raw
+   * inside a string.
+   */
+  private val FirstPrintableChar = ' '
+
+  /**
    * Validate a WKT/EWKT string for safe inclusion in a SQL literal.
    *
    * Two independent checks, neither of which depends on parser leniency:

--- a/app/persistence/postgresql/PostgresqlRepository.scala
+++ b/app/persistence/postgresql/PostgresqlRepository.scala
@@ -519,8 +519,6 @@ class PostgresqlRepository @Inject() (
   //
   //    Note that we cannot use prepared statements for DDL's
 
-  private def single_quote(str: String): String = "'" + str + "'"
-
   private val tr = (__ \ "geometry").json.prune
 
   private def stripGeometry(js: JsObject): JsObject = {
@@ -532,13 +530,30 @@ class PostgresqlRepository @Inject() (
 
   private def toColName(str: String): String = str.replaceAll("-", "_")
 
+  /**
+   * The geometry column of a collection, as a SQL identifier.
+   *
+   * Collections this server creates itself use the fixed `geometry` column.
+   * For a registered table the name arrived over HTTP and is stored as sent,
+   * so it is quoted here: unquoted it is SQL an admin can write from a request
+   * body, run by every query on that collection.
+   *
+   * Lower-casing first leaves the column this resolves to unchanged from when
+   * it was interpolated unquoted — PostgreSQL folds an unquoted identifier, so
+   * a registration of `GEOM` has always addressed the column `geom`.
+   */
+  private def geometryColumnOf(md: Metadata): String =
+    if (md.jsonTable) "geometry" else safeIdentifier(md.geometryColumn.toLowerCase)
+
   private def schemaIsExcluded(collName: String): Boolean = excludedSchemas match {
     case Some(col) => col.contains(collName)
     case _         => false
   }
 
+  // The result is spliced into SQL as text (see LIST_SCHEMA), so the values —
+  // configuration rather than request data — go through `safeLiteralString`.
   private def withExcludeSchemas(clause: String, prop: String) = {
-    def quoted(coll: Seq[String]) = coll.map(single_quote) mkString ","
+    def quoted(coll: Seq[String]) = coll.map(safeLiteralString) mkString ","
 
     (clause, excludedSchemas) match {
       case (c, Some(coll)) if c.isEmpty => s" $prop not in ( ${quoted(coll)} )"
@@ -566,7 +581,7 @@ class PostgresqlRepository @Inject() (
       case _ =>
         def colName(s: String): String = if (s.trim.startsWith("properties.")) s.trim.substring(11) else s.trim
 
-        if (query.sort.isEmpty) query.metadata.pkey else query.sort.map(f => s"${safeIdentifier(colName(f.fld))} ${f.direction}") mkString ","
+        if (query.sort.isEmpty) safeIdentifier(query.metadata.pkey) else query.sort.map(f => s"${safeIdentifier(colName(f.fld))} ${f.direction}") mkString ","
     }
 
     def wktGeometry(query: SpatialQuery): Option[String] = {
@@ -574,7 +589,7 @@ class PostgresqlRepository @Inject() (
     }
 
     def windowFilterExpr(query: SpatialQuery): Option[String] = {
-      val geomCol = if (query.metadata.jsonTable) "geometry" else query.metadata.geometryColumn
+      val geomCol = geometryColumnOf(query.metadata)
 
       def bboxIntersectionRenderer(wkt: String) = s"$geomCol && ${safeLiteralString(wkt)}::geometry"
 
@@ -583,7 +598,7 @@ class PostgresqlRepository @Inject() (
     }
 
     def renderContextFromSpatialQuery(query: SpatialQuery): RenderContext = {
-      val geomCol = if (query.metadata.jsonTable) "geometry" else query.metadata.geometryColumn
+      val geomCol = geometryColumnOf(query.metadata)
       val bboxGeom = wktGeometry(query)
 
       RenderContext(geomCol, bboxGeom)
@@ -598,7 +613,7 @@ class PostgresqlRepository @Inject() (
           PGJsonQueryRenderer
         }
       } else PGRegularQueryRenderer
-      val geomCol = if (query.metadata.jsonTable) "geometry" else query.metadata.geometryColumn
+      val geomCol = geometryColumnOf(query.metadata)
 
       def geomIntersectionRenderer(wkt: String) = s"ST_Intersects($geomCol, ${safeWkt(wkt)}::geometry)"
 
@@ -639,7 +654,7 @@ class PostgresqlRepository @Inject() (
 
       val projection =
         if (query.metadata.jsonTable) "ID, ST_AsEWKT( geometry) as geom , json"
-        else s" ${query.metadata.pkey}, ST_AsEWKT( ${query.metadata.geometryColumn}) as $geoJsonCol, * "
+        else s" ${safeIdentifier(query.metadata.pkey)}, ST_AsEWKT( ${geometryColumnOf(query.metadata)}) as $geoJsonCol, * "
 
       sql"""
          SELECT #$projection
@@ -770,13 +785,17 @@ class PostgresqlRepository @Inject() (
         WHERE #$where
      """
 
-    def LIST_TABLE_NAMES(dbname: String) = {
-      sqlu""" select table_name from information_schema.tables
+    // Both comparisons are against catalogue *values*, so they are bind
+    // parameters. Quoting them first — as `'x'` or `"x"` — made PostgreSQL
+    // compare against a string that carries the quote characters, matching
+    // nothing.
+    def LIST_TABLE_NAMES(dbname: String): DBIO[Seq[String]] = {
+      sql""" select table_name from information_schema.tables
               where
-              table_schema = ${single_quote(dbname)}
+              table_schema = $dbname
               and table_type = 'BASE TABLE'
-              and table_name != ${safeIdentifier(MetadataCollection)}
-       """
+              and table_name != $MetadataCollection
+       """.as[String]
     }
 
     def INSERT_METADATA_JSON_COLLECTION(dbname: String, tableName: String, md: Metadata) =

--- a/app/persistence/querylang/QueryParser.scala
+++ b/app/persistence/querylang/QueryParser.scala
@@ -115,12 +115,18 @@ class QueryParser(val input: ParserInput) extends Parser
 
   val printableChar = (CharPredicate.All -- "'")
 
-  //a Literal String is quoted using single quotes. To use singe quotes in the string, simply repeat the quote twice (with no whitespace).
-  def LiteralStr = rule { '\'' ~ clearSB() ~ zeroOrMore((printableChar | "''") ~ appendSB()) ~ '\'' ~ push(LiteralString(sb.toString)) }
+  // String literals are single-quoted. Represent an apostrophe by doubling it.
+  def LiteralStr = rule { '\'' ~ clearSB() ~ zeroOrMore(QuotedStringChar) ~ '\'' ~ push(LiteralString(sb.toString)) }
 
   def Regex = rule { '/' ~ clearSB() ~ zeroOrMore((noneOf("/") ~ appendSB())) ~ '/' ~ push(RegexExpr(sb.toString)) }
 
-  def Like = rule { '\'' ~ clearSB() ~ zeroOrMore((printableChar | "\'\'") ~ appendSB()) ~ '\'' ~ push(LikeExpr(sb.toString)) }
+  def Like = rule { '\'' ~ clearSB() ~ zeroOrMore(QuotedStringChar) ~ '\'' ~ push(LikeExpr(sb.toString)) }
+
+  // Match doubled quotes explicitly instead of using the implicit `wspStr`
+  // conversion. `wspStr` also consumes trailing spaces, causing no-arg
+  // `appendSB()` to append the final space instead of the escaped apostrophe.
+  // Appending '\'' explicitly preserves both the quote and following whitespace.
+  def QuotedStringChar = rule { (str("''") ~ appendSB('\'')) | (printableChar ~ appendSB()) }
 
   def Property = rule { capture(NameString) ~> PropertyExpr ~ WS }
 

--- a/test/controllers/ExceptionHandlersSpec.scala
+++ b/test/controllers/ExceptionHandlersSpec.scala
@@ -1,0 +1,28 @@
+package controllers
+
+import org.specs2.mutable.Specification
+import play.api.http.Status._
+import play.api.mvc.Result
+
+class ExceptionHandlersSpec extends Specification with ExceptionHandlers {
+
+  private def statusOf(r: Result): Int = r.header.status
+  private def bodyOf(r: Result): String = {
+    import org.apache.pekko.stream.Materializer
+    import org.apache.pekko.util.ByteString
+    import scala.concurrent.Await
+    import scala.concurrent.duration._
+    implicit val mat: Materializer = Materializer.matFromSystem(org.apache.pekko.actor.ActorSystem("test-mat"))
+    val bytes: ByteString = Await.result(r.body.consumeData, 5.seconds)
+    bytes.utf8String
+  }
+
+  "commonExceptionHandler" should {
+
+    "return a generic 500 response without leaking exception details" in {
+      val result = commonExceptionHandler.apply(new RuntimeException("sensitive backend detail"))
+      statusOf(result) must_=== INTERNAL_SERVER_ERROR
+      bodyOf(result) must_=== "Internal server error."
+    }
+  }
+}

--- a/test/integration/QueryAPISpec.scala
+++ b/test/integration/QueryAPISpec.scala
@@ -6,6 +6,7 @@ import play.api.libs.json._
 import org.geolatte.geom.Envelope
 import java.net.URLEncoder._
 import scala.collection.Seq
+import scala.util.Try
 
 /**
  * @author Karel Maesen, Geovise BVBA
@@ -52,6 +53,19 @@ class QueryAPISpec extends InCollectionSpecification {
      Projection may specify fields not in inputJson (works only on postgresql)
         with Json output, fields are set to JsNull                                  $e16
         with CSV output, fields are empty strings                                   $e17
+
+     The QUERY parameter on a JSONB collection should:
+        support the IS NULL predicate                                                $e18
+        support the IS NOT NULL predicate                                            $e19
+        support the regex predicate, honouring backslash escapes                     $e20
+        support the JSON-contains predicate                                          $e21
+        support to_date comparisons                                                  $e22
+
+     Query values are data, never SQL — a JSONB collection should:
+        match a value containing a single quote                                      $e23
+        match a value containing a double quote and a backslash                      $e24
+        not let a quoted payload in an equality break out of the query               $e25
+        not let a quoted payload in a JSON-contains break out of the query           $e26
 
   """
 
@@ -280,6 +294,113 @@ class QueryAPISpec extends InCollectionSpecification {
         }
       }
   }
+
+  // The test collection is JSONB-encoded (the create-collection default), so
+  // these run through PGJsonpathQueryRenderer. That renderer builds a jsonpath
+  // expression which the repository splices into the SQL text as a string
+  // literal, so a value crosses two quoting layers on its way to the database.
+  // Asserting on the rendered string alone (PGQueryRenderSpec) cannot show that
+  // PostgreSQL accepts the result, which is what these exercise.
+
+  def e18 = withFeaturesHavingProperties(Json.obj("code" -> JsNull), Json.obj("code" -> "bla")) {
+    features =>
+      queryFeatures("properties.code is null") applyMatcher {
+        res => res.responseBody must beSomeFeatures(JsArray(Seq(features.value.head)))
+      }
+  }
+
+  def e19 = withFeaturesHavingProperties(Json.obj("code" -> JsNull), Json.obj("code" -> "bla")) {
+    features =>
+      queryFeatures("properties.code is not null") applyMatcher {
+        res => res.responseBody must beSomeFeatures(JsArray(Seq(features.value(1))))
+      }
+  }
+
+  // `\d` has to reach the regex engine as a digit class. Before the values in a
+  // jsonpath were escaped, PostgreSQL swallowed the backslash and matched a
+  // literal `d` instead — silently, without an error.
+  def e20 = withFeaturesHavingProperties(Json.obj("code" -> "bla5bla"), Json.obj("code" -> "blaXbla")) {
+    features =>
+      queryFeatures("""properties.code ~ /bla\d+bla/""") applyMatcher {
+        res => res.responseBody must beSomeFeatures(JsArray(Seq(features.value.head)))
+      }
+  }
+
+  def e21 = withFeaturesHavingProperties(
+    Json.obj("tags" -> Json.arr("bla", 2)),
+    Json.obj("tags" -> Json.arr("blabla"))) {
+      features =>
+        queryFeatures("""properties.tags @> '["bla"]'""") applyMatcher {
+          res => res.responseBody must beSomeFeatures(JsArray(Seq(features.value.head)))
+        }
+    }
+
+  def e22 = withFeaturesHavingProperties(
+    Json.obj("datum" -> "2019-04-30"),
+    Json.obj("datum" -> "2020-01-01")) {
+      features =>
+        queryFeatures("to_date(properties.datum, 'YYYY-MM-DD') = to_date('2019-04-30', 'YYYY-MM-DD')") applyMatcher {
+          res => res.responseBody must beSomeFeatures(JsArray(Seq(features.value.head)))
+        }
+    }
+
+  def e23 = withFeaturesHavingProperties(Json.obj("foo" -> "bla'bla"), Json.obj("foo" -> "blabla")) {
+    features =>
+      queryFeatures("properties.foo = 'bla''bla'") applyMatcher {
+        res => res.responseBody must beSomeFeatures(JsArray(Seq(features.value.head)))
+      }
+  }
+
+  def e24 = withFeaturesHavingProperties(Json.obj("foo" -> """bla "bla" C:\bla"""), Json.obj("foo" -> "blabla")) {
+    features =>
+      queryFeatures("""properties.foo = 'bla "bla" C:\bla'""") applyMatcher {
+        res => res.responseBody must beSomeFeatures(JsArray(Seq(features.value.head)))
+      }
+  }
+
+  // The payload from the reported SQL injection. It has to come back as an
+  // ordinary string comparison that matches the feature literally holding it —
+  // proof the value never reached SQL statement context.
+  def e25 = {
+    val payload = """bla'::jsonb OR '1'='1"""
+    withFeaturesHavingProperties(Json.obj("foo" -> payload), Json.obj("foo" -> "bla")) {
+      features =>
+        queryFeatures(s"properties.foo = '${payload.replace("'", "''")}'") applyMatcher {
+          res => res.responseBody must beSomeFeatures(JsArray(Seq(features.value.head)))
+        }
+    }
+  }
+
+  // Same payload against `@>`, the operator the report weaponised. Escaped, it
+  // is no longer valid JSON, so PostgreSQL rejects the statement and the
+  // streaming response fails; unescaped, it made the WHERE clause
+  // unconditionally true and streamed back the whole collection. Only that last
+  // outcome is a leak, so the assertion is on it rather than on any particular
+  // error handling: the request must not succeed with every feature.
+  def e26 = withFeaturesHavingProperties(
+    Json.obj("tags" -> Json.arr("bla")),
+    Json.obj("tags" -> Json.arr("blabla"))) {
+      features =>
+        val attempt = Try(queryFeatures("""properties.tags @> '1''::jsonb OR ''1''=''1'""").responseBody)
+        attempt.toOption.flatten must not(beSomeFeatures(features))
+    }
+
+  /**
+   * Load features whose properties are exactly the given objects, all inside
+   * the same bbox, and hand the loaded array to the block in that order.
+   */
+  def withFeaturesHavingProperties[T](props: JsObject*)(block: JsArray => T): T = {
+    val generated = gjFeatureArrayGenerator("01", props.size).sample.get
+    val features = JsArray(generated.value.zip(props).map {
+      case (feature, properties) => feature.as[JsObject] ++ Json.obj("properties" -> properties)
+    })
+    withFeatures(testDbName, testColName, features) {
+      block(features)
+    }
+  }
+
+  def queryFeatures(query: String) =
+    getQuery(testDbName, testColName, Map("query" -> encode(query, "UTF-8")))(contentAsJsonStream)
 
   def withTestFeatures[T](sizeInsideBbox: Int, sizeOutsideBbox: Int)(block: (String, JsArray) => T) = {
     val (featuresIn01, allFeatures) = gjFeatureArrayGenerator("01", sizeInsideBbox)

--- a/test/integration/RegisterCollectionAPISpec.scala
+++ b/test/integration/RegisterCollectionAPISpec.scala
@@ -1,0 +1,118 @@
+package integration
+
+import java.net.URLEncoder.encode
+
+import persistence.Repository
+import persistence.postgresql.PostgresqlRepository
+import play.api.libs.json._
+import slick.jdbc.PostgresProfile.api._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.Try
+
+/**
+ * Registering an existing table is the one route by which a column name
+ * travels from a request body into the text of every later query on that
+ * collection. These run that route against a real table.
+ */
+class RegisterCollectionAPISpec extends InDatabaseSpecification {
+
+  def is = s2"""
+
+      Registering an existing table should:
+        return CREATED for a table with a geometry column                                   $e1
+        serve a query against the registered table                                          $e2
+        serve a query when the column was registered in a different case                    $e3
+
+      A geometry column is a name, never SQL — a registered table should:
+        not run a payload that closes the identifier                                        $e4
+
+    """
+
+  import UtilityMethods._
+  import API._
+
+  def e1 = createTableAndRegister("regcoll", "geom").status must equalTo(CREATED)
+
+  // The registered table is served through PGRegularQueryRenderer, and its
+  // geometry column and primary key are now quoted identifiers. Only a round
+  // trip shows that the quoted forms still address the columns; a rendered
+  // string proves nothing about what PostgreSQL accepts.
+  def e2 = {
+    insertRow("regcoll", "first")
+    queryLabels("regcoll", "label = 'first'") must beSome(Seq("first"))
+  }
+
+  // PostgreSQL folds an unquoted identifier, so registering `GEOM` for a column
+  // named `geom` used to work. Quoting the name would have ended that if it
+  // were not lower-cased first.
+  def e3 = {
+    createTableAndRegister("casedcoll", "geom", registerAs = Some("GEOM"))
+    insertRow("casedcoll", "second")
+    queryLabels("casedcoll", "label = 'second'") must beSome(Seq("second"))
+  }
+
+  // The payload closes the ST_AsEWKT call, adds a column of its own, and
+  // reopens the call so the statement stays valid — unquoted it therefore ran,
+  // and every feature came back carrying `leaked`. Quoted it is a single column
+  // name, no such column exists, and the query yields nothing. The assertion is
+  // on the leak rather than on any particular failure: what must never happen
+  // is that the subselect is answered.
+  def e4 = {
+    val payload = """geom), (select current_setting('is_superuser')) as leaked, ST_AsEWKT(geom"""
+    createTableAndRegister("injectcoll", "geom", registerAs = Some(payload))
+    insertRow("injectcoll", "third")
+    queryValuesOf("leaked", "injectcoll", "label = 'third'") must beEmpty
+  }
+
+  private lazy val repository =
+    currentApp.injector.instanceOf[Repository].asInstanceOf[PostgresqlRepository]
+
+  private def runSql(statement: DBIO[Int]): Unit =
+    Await.result(repository.database.run(statement), 10.seconds)
+
+  /**
+   * Create a plain PostGIS table — the kind this server does not own and can
+   * only register — and offer it to the register endpoint.
+   */
+  private def createTableAndRegister(collection: String, geometryColumn: String, registerAs: Option[String] = None) = {
+    runSql(
+      sqlu"""create table #${quoted(testDbName)}.#${quoted(collection)} (
+               id serial primary key,
+               #${quoted(geometryColumn)} geometry(Point, 31370),
+               label varchar(255)
+             )"""
+    )
+    val body = Json.obj(
+      "collection" -> collection,
+      "geometry-column" -> registerAs.getOrElse[String](geometryColumn),
+      "extent" -> Json.obj(
+        "crs" -> 31370,
+        "envelope" -> Json.arr(0.0, 0.0, 1000000.0, 1000000.0)
+      )
+    )
+    FakeRequestResult.POSTJson(DATABASES / testDbName / "register", body, contentAsJson)
+  }
+
+  private def insertRow(collection: String, label: String): Unit =
+    runSql(
+      sqlu"""insert into #${quoted(testDbName)}.#${quoted(collection)} (geom, label)
+             values (st_setsrid(st_makepoint(1, 1), 31370), $label)"""
+    )
+
+  private def queryLabels(collection: String, query: String): Option[Seq[String]] =
+    queryFor(collection, query, "label").map(_.map(_.as[String]))
+
+  /** Empty when the query does not come back at all, which is a non-leak too. */
+  private def queryValuesOf(field: String, collection: String, query: String): Seq[JsValue] =
+    Try(queryFor(collection, query, field)).toOption.flatten.getOrElse(Nil)
+
+  private def queryFor(collection: String, query: String, field: String): Option[Seq[JsValue]] =
+    getQuery(testDbName, collection, Map("query" -> encode(query, "UTF-8")))(contentAsJsonStream)
+      .responseBody
+      .map(js => (js \\ field).toSeq)
+
+  private def quoted(name: String): String = s""""$name""""
+
+}

--- a/test/persistence/postgresql/PGQueryRenderSpec.scala
+++ b/test/persistence/postgresql/PGQueryRenderSpec.scala
@@ -1,7 +1,7 @@
 package persistence.postgresql
 
 import org.specs2.mutable.Specification
-import persistence.querylang.{ QueryParser, BooleanExpr }
+import persistence.querylang._
 
 /**
  * Created by Karel Maesen, Geovise BVBA on 23/01/15.
@@ -142,6 +142,12 @@ class PGQueryRenderSpec extends Specification {
       compressWS(renderer.render(expr)) === "json @?? '$.properties.foo ? ( @ == \"bar1\" )'"
     }
 
+    "safely render apostrophes and JSONPath delimiters in equality expressions" in {
+      val expr = ComparisonPredicate(PropertyExpr("properties.foo"), EQ, LiteralString("O'Brien \"quoted\""))
+      compressWS(renderer.render(expr)) ===
+        """json @?? '$.properties.foo ? ( @ == "O''Brien \"quoted\"" )'"""
+    }
+
     "properly render boolean expressions containing comparison expresssions other than equality " in {
 
       val expr1 = QueryParser.parse("ab.cd > 12").get
@@ -190,6 +196,22 @@ class PGQueryRenderSpec extends Specification {
       compressWS(renderer.render(expr)) === "json @?? '$.properties.foo ? (@ like_regex \"bar1.*\")'"
     }
 
+    "safely render apostrophes and JSONPath delimiters in regex expressions" in {
+      val expr = RegexPredicate(PropertyExpr("properties.foo"), RegexExpr("O'Brien \"quoted\""))
+      compressWS(renderer.render(expr)) ===
+        """json @?? '$.properties.foo ? (@ like_regex "O''Brien \"quoted\"")'"""
+    }
+
+    // A backslash has to survive the jsonpath string layer doubled, or the
+    // regex engine never sees it: PostgreSQL accepts an unknown jsonpath escape
+    // and silently drops the backslash, so an unescaped `\d` would arrive as a
+    // literal `d` and the pattern would quietly match the wrong rows.
+    "double backslashes in a regex so the escape reaches the regex engine" in {
+      val expr = RegexPredicate(PropertyExpr("properties.code"), RegexExpr("""a\d+b"""))
+      compressWS(renderer.render(expr)) ===
+        """json @?? '$.properties.code ? (@ like_regex "a\\d+b")'"""
+    }
+
     "properly render simple like expression " in {
       val expr = QueryParser.parse("properties.foo like 'a%bcd'").get
       compressWS(renderer.render(expr)) === "( json->'properties'->>'foo' )::text like 'a%bcd'"
@@ -225,6 +247,12 @@ class PGQueryRenderSpec extends Specification {
       compressWS(renderer.render(expr)) === """( json->'properties'->'test' ) @> '["a", 2]'::jsonb"""
     }
 
+    "safely render apostrophes in JsonContains expressions" in {
+      val expr = JsonContainsPredicate(PropertyExpr("properties.test"), LiteralString("""{"name":"O'Brien"}"""))
+      compressWS(renderer.render(expr)) ===
+        """( json->'properties'->'test' ) @> '{"name":"O''Brien"}'::jsonb"""
+    }
+
     "properly render to_date functions in expression" in {
       val expr = QueryParser.parse(" to_date(properties.foo, 'YYYY-MM-DD') = to_date('2019-04-30', 'YYYY-MM-DD') ").get
       compressWS(renderer.render(expr)) === """json @?? '$.properties.foo.datetime( "YYYY-MM-DD" ) ? ( @ == "2019-04-30" .datetime( "YYYY-MM-DD" ))'"""
@@ -253,6 +281,14 @@ class PGQueryRenderSpec extends Specification {
     "properly render simple equality expression " in {
       val expr = QueryParser.parse("properties.foo = 'bar1'").get
       compressWS(renderer.render(expr)) === """"foo" = ( 'bar1' )"""
+    }
+
+    // No parser produces a property name holding a double quote, so this
+    // expression is built by hand: the point is that the renderer closes the
+    // identifier itself rather than leaning on the grammar to do it.
+    "escape a double quote in a property name rather than close the identifier" in {
+      val expr = ComparisonPredicate(PropertyExpr("""foo" , (select 1) as "x"""), EQ, LiteralString("bar"))
+      compressWS(renderer.render(expr)) === """"foo"" , (select 1) as ""x" = ( 'bar' )"""
     }
 
     "properly render boolean expressions containing comparison expresssions other than equality " in {

--- a/test/persistence/postgresql/PGSqlUtilsSpec.scala
+++ b/test/persistence/postgresql/PGSqlUtilsSpec.scala
@@ -42,4 +42,21 @@ class PGSqlUtilsSpec extends Specification {
         .reduce(_ and _)
     }
   }
+
+  "PGSqlUtils.safeJsonpathString" should {
+    "escape JSON string delimiters, backslashes and control characters" in {
+      PGSqlUtils.safeJsonpathString("a\"b\\c\n") === "\"a\\\"b\\\\c\\n\""
+    }
+
+    // U+0001 built from its code point: the character is invisible in an
+    // editor, and a source-level \u escape is resolved by the Scala lexer
+    // before the string ever exists.
+    "escape a control character that has no named JSON escape" in {
+      PGSqlUtils.safeJsonpathString("a" + 1.toChar + "b") === "\"a\\u0001b\""
+    }
+
+    "leave characters JSON does not require escaping untouched" in {
+      PGSqlUtils.safeJsonpathString("categorieën a/b") === "\"categorieën a/b\""
+    }
+  }
 }

--- a/test/persistence/querylang/QueryParserSpec.scala
+++ b/test/persistence/querylang/QueryParserSpec.scala
@@ -71,6 +71,33 @@ class QueryParserSpec extends Specification {
 
     }
 
+    // An escaped quote used to be matched by a bare "''" in the rule, which
+    // picked up the implicit whitespace-eating conversion: the apostrophe was
+    // replaced by a space and any run of spaces behind it collapsed to one.
+    "keep an escaped quote that is followed by whitespace" in {
+
+      (
+        QueryParser.parse(" var = 'bla'' bla' ") must beSuccessfulTry[BooleanExpr].withValue(
+          ComparisonPredicate(PropertyExpr("var"), EQ, LiteralString("bla' bla"))
+        )
+      ) and (
+            QueryParser.parse(" var = 'bla''  bla' ") must beSuccessfulTry[BooleanExpr].withValue(
+              ComparisonPredicate(PropertyExpr("var"), EQ, LiteralString("bla'  bla"))
+            )
+          ) and (
+                QueryParser.parse(" var = 'bla''' ") must beSuccessfulTry[BooleanExpr].withValue(
+                  ComparisonPredicate(PropertyExpr("var"), EQ, LiteralString("bla'"))
+                )
+              )
+
+    }
+
+    "keep an escaped quote that is followed by whitespace in a like pattern" in {
+      QueryParser.parse(" var like 'bla'' %' ") must beSuccessfulTry[BooleanExpr].withValue(
+        LikePredicate(PropertyExpr("var"), LikeExpr("bla' %"))
+      )
+    }
+
     "handle negations properly" in {
 
       (


### PR DESCRIPTION
 - escape JSONPath strings and surrounding SQL literals
  - preserve escaped apostrophes and whitespace in query values
  - prevent exception details from leaking in 500 responses
  - add unit and integration regression tests